### PR TITLE
Use `Sync.blocking` for flag evaluations

### DIFF
--- a/core/src/main/scala/io/github/bplommer/launchcatsly/LaunchDarklyClient.scala
+++ b/core/src/main/scala/io/github/bplommer/launchcatsly/LaunchDarklyClient.scala
@@ -52,7 +52,7 @@ object LaunchDarklyClient {
         new LaunchDarklyClient.Default[F] {
 
           override def unsafeWithJavaClient[A](f: LDClient => A): F[A] =
-            F.delay(f(ldClient))
+            F.blocking(f(ldClient))
 
           override def listen(featureKey: String, user: LDUser): Stream[F, FlagValueChangeEvent] =
             Stream.eval(F.delay(ldClient.getFlagTracker)).flatMap { tracker =>


### PR DESCRIPTION
Changed as some datastores, such as the Redis one, can do blocking IO as part of a flag evaluation